### PR TITLE
Improve contact handling

### DIFF
--- a/modules/registrars/rrpproxy/tlds/swiss.php
+++ b/modules/registrars/rrpproxy/tlds/swiss.php
@@ -3,3 +3,4 @@
 $extensions['class'] = "SWISS-GOLIVE";
 $extensions['X-INTENDED-USE'] = $params["additionalfields"]['Intended Use'];
 $extensions['X-SWISS-UID'] = $params["additionalfields"]['UID'];
+$domainApplication = true;


### PR DESCRIPTION
- No longer forces the creation of new contact handles on each domain registration
- Now uses the Admin/Billing/Tech contact as configured in WHMCS. The "Use Clients Details" setting in WHMCS defines what we get as admin contact in $params. If the option is selected, it will be the same as the owner and the API will return the owner handle.
- Fixed domain registration for .swiss domains, as they need to use AddDomainApplication instead of AddDomain