### PR TITLE
Fix domain synchronisation cron crash 

### DIFF
--- a/modules/registrars/keysystems/keysystems.php
+++ b/modules/registrars/keysystems/keysystems.php
@@ -1288,7 +1288,7 @@ function keysystems_TransferSync($params)
         if ($params["NSUpdTransfer"] == "on") {
             // Get order
             $order = DB::table('tblorders as o')
-                ->join('tbldomains as d', 'd.orderid', 'o.id')
+                ->join('tbldomains as d', 'd.orderid', '=', 'o.id')
                 ->where('d.domain', $domain)
                 ->select('o.userid', 'o.contactid', 'o.nameservers')
                 ->orderBy('id', 'DESC')

--- a/modules/registrars/keysystems/keysystems.php
+++ b/modules/registrars/keysystems/keysystems.php
@@ -1291,7 +1291,7 @@ function keysystems_TransferSync($params)
                 ->join('tbldomains as d', 'd.orderid', '=', 'o.id')
                 ->where('d.domain', $domain)
                 ->select('o.userid', 'o.contactid', 'o.nameservers')
-                ->orderBy('id', 'DESC')
+                ->orderBy('o.id', 'DESC')
                 ->first();
 
             // Set nameservers if defined in order


### PR DESCRIPTION
TransferSync function has a mistake in query builder join method call so invalid SQL was generated and lead domain synchronisation cron to crash