### PR TITLE
feat(getdomaininformation): extended to also return addon status

### DIFF
--- a/modules/registrars/keysystems/keysystems.php
+++ b/modules/registrars/keysystems/keysystems.php
@@ -227,9 +227,13 @@ function keysystems_GetDomainInformation(array $params)
             && !empty($forwardings)
         );
         // dns management
-        $response = $api->call('CheckDNSZone', [
-            'dnszone' => $params['domainname']
-        ]);
+        try {
+            $response = $api->call('CheckDNSZone', [
+                'dnszone' => $params['domainname']
+            ]);
+        } catch (Exception $ex) {
+            $response['code'] = 0;
+        }
         $domain->setDnsManagementStatus($response['code'] != 210);
 
         // id protection


### PR DESCRIPTION
Hi @h9k,

please review & test my extension of GetDomainInformation. The idea behind is to have this information available for the Domain Import Addon I am currently working on for RRP/HX. Allowing us to write a more generic code base there.

I removed a try catch block as it was nested in a try catch doing exactly the same, superfluous imho. If I am wrong with that, let me know.

ty!